### PR TITLE
override templates with image_tag, use empty alt

### DIFF
--- a/lib/generators/spotlight/tamu/app/views/spotlight/about_pages/_contact_properties.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/about_pages/_contact_properties.html.erb
@@ -1,0 +1,13 @@
+<%= image_tag contact.avatar.iiif_url, alt: "", class: 'contact-photo' if contact.avatar && contact.avatar.iiif_url.present? %>
+<div itemprop="name" class="name"><%= contact.name %></div>
+<% Spotlight::Contact.fields.each do |field, options| %>
+  <% if (value = contact.contact_info[field]).present? %>
+    <div itemprop="<%= options[:itemprop] || field %>">
+      <% if options[:helper] %>
+        <%= send(options[:helper], value) %>
+      <% else %>
+        <%= value %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/appearances/edit.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/appearances/edit.html.erb
@@ -1,0 +1,111 @@
+<%= render 'spotlight/shared/exhibit_sidebar' %>
+<div id="content" class="col-md-9">
+  <%= configuration_page_title %>
+
+<%= bootstrap_form_for @exhibit, url: spotlight.exhibit_appearance_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5', html: {data: { autocomplete_exhibit_catalog_path: spotlight.autocomplete_exhibit_catalog_path(current_exhibit, q: "%QUERY", format: "json") } } do |f| %>
+  <% if @exhibit.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(@exhibit.errors.count, "error") %> prohibited this page from being saved:</h2>
+
+      <ul>
+      <% @exhibit.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <div role="tabpanel">
+    <ul class="nav nav-tabs" role="tablist">
+      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+        <li role="presentation" class="active">
+          <a href="#site-theme" aria-controls="site-theme" role="tab" data-toggle="tab"><%= t(:'.site_theme.heading') %></a>
+        </li>
+      <% end %>
+
+      <li role="presentation" <%= 'class="active"'.html_safe unless Spotlight::Engine.config.exhibit_themes.many? %>>
+        <a href="#site-masthead" aria-controls="site-masthead" role="tab" data-toggle="tab"><%= t(:'.site_masthead.heading') %></a>
+      </li>
+
+      <li role="presentation">
+        <a href="#site-thumbnail" aria-controls="site-thumbnail" role="tab" data-toggle="tab"><%= t(:'.site_thumbnail.heading') %></a>
+      </li>
+
+      <li role="presentation">
+        <a href="#main-menu" aria-controls="main-menu" role="tab" data-toggle="tab"><%= t(:'.main_navigation.menu') %></a>
+      </li>
+    </ul>
+    <div class="tab-content">
+      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+      <div role="tabpanel" class="tab-pane active" id="site-theme">
+        <p class="instructions"><%= t(:'.site_theme.help') %></p>
+        <%= f.form_group :theme, label: { text: t(:'.site_theme.label') } do %>
+          <% Spotlight::Engine.config.exhibit_themes.each do |theme| %>
+            <div class="col-md-6">
+              <%= image_tag "spotlight/themes/#{theme}_preview.png", alt: "", width: 100, height: 100 %>
+              <%= f.radio_button :theme, theme, label: t(:".site_theme.#{theme}", default: theme.to_s.titleize), inline: true %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+      <% end %>
+
+      <div role="tabpanel" class="tab-pane <%= 'active' unless Spotlight::Engine.config.exhibit_themes.many? %>" id="site-masthead">
+        <p class="instructions"><%= t(:'.site_masthead.help') %></p>
+        <%= f.fields_for(:masthead, current_exhibit.masthead || current_exhibit.build_masthead) do |m| %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
+        <% end %>
+      </div>
+
+      <div role="tabpanel" class="tab-pane" id="site-thumbnail">
+        <p class="instructions"><%= t(:'.site_thumbnail.help') %></p>
+        <%= f.fields_for(:thumbnail, current_exhibit.thumbnail || current_exhibit.build_thumbnail) do |m| %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.thumbnail_initial_crop_selection, crop_type: :thumbnail %>
+        <% end %>
+      </div>
+
+      <div role="tabpanel" class="tab-pane" id="main-menu">
+        <%= field_set_tag do %>
+          <p class="instructions"><%= t(:'.main_navigation.help') %></p>
+          <div class="panel-group dd main_navigation_admin col-sm-7" id="nested-navigation" data-behavior="nestable" data-max-depth="1">
+            <ol class="dd-list">
+              <%= f.fields_for :main_navigations do |label| %>
+                    <li class="dd-item dd3-item" data-id="<%= label.object.id %>">
+                      <div class="dd3-content panel panel-default">
+                        <div class="dd-handle dd3-handle"><%= t :drag %></div>
+                        <div class="panel-heading" data-behavior="restore-default">
+                          <%= label.hidden_field :id %>
+                          <div class="row">
+                            <div class="col-sm-8">
+                              <div class='publish-control'>
+                                <%= label.check_box_without_bootstrap :display %>
+                              </div>
+                              <div class="main">
+                                <h3 class="panel-title" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
+                                  <a href="#edit-in-place" class="field-label edit-in-place"><%= label.object.label_or_default %></a>
+                                  <%= label.hidden_field :label, data: {:"default-value" => label.object.default_label, :"edit-field-target" => 'true'} %>
+                                </h3>
+                              </div>
+                            </div>
+                            <div class="col-sm-4">
+                              <%= button_tag t(:'.restore_default'), data: {:"restore-default" => true}, class: "btn restore-default btn-default btn-sm pull-right #{'hidden' if label.object.label.blank? || label.object.label == label.object.default_label}" %>
+                            </div>
+                          </div>
+                          <%= label.hidden_field :weight, data: {property: "weight"} %>
+                        </div>
+                      </div>
+                    </li>
+              <% end %>
+            </ol>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>
+</div>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/browse/_search.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/browse/_search.html.erb
@@ -1,0 +1,15 @@
+<%= cache [@exhibit, search] do %>
+  <div class="col-sm-4 col-xs-12 category">
+    <%= link_to spotlight.exhibit_browse_path(@exhibit, search) do %>
+      <div class="image-overlay">
+        <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', alt: "", class: 'img-responsive') %>
+        <div class="text-overlay">
+           <h2 class="browse-category-title">
+             <%= search.title%>
+             <small><%= t :'spotlight.browse.search.item_count', count: search.documents.size %></small>
+           </h2>
+         </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
@@ -1,0 +1,11 @@
+<% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
+  <%= image_tag(exhibit.thumbnail.iiif_url, alt: "") %>
+<% else %>
+  <%= image_tag 'spotlight/default_thumbnail.jpg', alt: "", class: 'default-thumbnail' %>
+<% end %>
+
+<% unless exhibit.published? %>
+  <div class="label label-warning unpublished"><%= t('.unpublished') %></div>
+<% end %>
+
+<h2 class="card-title"><%= exhibit.title %></h2>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/searches/_search.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/searches/_search.html.erb
@@ -1,0 +1,29 @@
+<% search = f.object %>
+<li class="dd-item dd3-item" data-id="<%= search.id %>">
+  <div class="dd-handle dd3-handle"><%= t :drag %></div>
+  <div class="dd3-content panel panel-default">
+    <div class="panel-heading search">
+      <%= f.check_box :published, label: '' %>
+
+      <div class="pic thumbnail">
+        <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', alt: "", class: 'img-responsive') %>
+      </div>
+      <div class="main">
+        <div class="title panel-title"><%= search.title %></div>
+        <div class="count"><%= t :'.item_count', count: search.documents.size %></div>
+        <div class="actions"><%= exhibit_view_link(search) %> &bull; <%= exhibit_edit_link(search) %> &bull; <%= exhibit_delete_link(search) %></div>
+        <%= f.hidden_field :id %>
+        <%= f.hidden_field :weight, data: {property: "weight"} %>
+      </div>
+
+      <div class="description">
+        <% if search.long_description.present? %>
+          <%= truncate(search.long_description, length: 89) %>
+        <% else %>
+          <span class="missing-description"><%= t(:'.missing_description_html', link: (link_to action_label(search, :edit_long), [spotlight, :edit, search.exhibit, search])) %></span>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+</li>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_image_block.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_image_block.html.erb
@@ -1,0 +1,5 @@
+<% if image_block.file && image_block.file[:url] -%>
+  <figure class="st__content-block st__content-block--image">
+    <%= image_tag image_block.file[:url], alt: "" %>
+  </figure>
+<% end -%>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -1,0 +1,45 @@
+<% solr_documents_block.with_solr_helper(self) %>
+
+<div class="content-block items-block row">
+  <% if solr_documents_block.documents? %>
+
+    <div class="items-col spotlight-flexbox pull-<%= solr_documents_block.content_align %> <%= solr_documents_block.text? ? "col-md-6" : "col-md-12" %> ">
+      <% solr_documents_block.each_document do |block_options, document| %>
+        <% doc_presenter = index_presenter(document) %>
+        <div class="box" data-id="<%= document.id %>">
+          <div class="contents">
+            <% if block_options[:thumbnail_image_url].present? %>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: ""), counter: -1) %></div>
+            <% elsif block_options[:iiif_tilesource_base].present?  %>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg', alt: ""), counter: -1) %></div>
+            <% elsif has_thumbnail? document %>
+              <div class="thumbnail"><%= render_thumbnail_tag(document, {}, document_counter: -1) %></div>
+            <% end %>
+            <% if solr_documents_block.primary_caption? %>
+              <div class="caption primary-caption">
+                <%= doc_presenter.field_value solr_documents_block.primary_caption_field %>
+              </div>
+            <% end %>
+            <% if solr_documents_block.secondary_caption? %>
+              <div class="caption secondary-caption">
+                <%= doc_presenter.field_value solr_documents_block.secondary_caption_field %>
+              </div>
+            <% end %>
+            <% if solr_documents_block.zpr_link? && block_options[:iiif_tilesource].present? %>
+              <button class="btn btn-default zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>">Show in ZPR viewer</button>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if solr_documents_block.text? %>
+    <div class="text-col col-md-6">
+      <% unless solr_documents_block.title.blank? %>
+        <h3><%= solr_documents_block.title %></h3>
+      <% end %>
+      <%= sir_trevor_markdown solr_documents_block.text %>
+    </div>
+  <% end %>
+</div>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -1,0 +1,51 @@
+<% solr_documents_carousel_block.with_solr_helper(self) %>
+<% indicators = [] %>
+<% html_id = "carousel-#{solr_documents_carousel_block.object_id}" %>
+<div class="content-block carousel-block carousel-height-<%= solr_documents_carousel_block.max_height %>">
+<% if solr_documents_carousel_block.documents? %>
+  <div id="<%= html_id %>" class="carousel slide" data-ride="carousel"  data-interval="<%= solr_documents_carousel_block.interval %>">
+    <div class="carousel-inner">
+    <% solr_documents_carousel_block.each_document.each_with_index do |(block_options, document), index| %>
+      <% doc_presenter = index_presenter(document) %>
+      <div class="item <%= 'active' if index == 0 %>" data-id="<%= document.id %>">
+        <% if block_options[:full_image_url].present? %>
+          <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: ""), counter: -1) %>
+        <% elsif block_options[:iiif_tilesource_base].present?  %>
+          <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg', alt: ""), counter: -1) %>
+        <% elsif has_thumbnail? document %>
+          <%= render_thumbnail_tag(document, {}, document_counter: -1) %>
+        <% end %>
+        <div class="carousel-caption">
+          <% if solr_documents_carousel_block.primary_caption? %>
+            <h3 class="primary">
+              <%= doc_presenter.field_value solr_documents_carousel_block.primary_caption_field %>
+            </h3>
+          <% end %>
+          <% if solr_documents_carousel_block.secondary_caption? %>
+            <div class="secondary">
+              <%= doc_presenter.field_value solr_documents_carousel_block.secondary_caption_field %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <% indicators << capture do %>
+        <li data-target="#<%= html_id %>" data-slide-to="<%= index %>" class="<%= 'active' if index == 0 %>"></li>
+      <% end %>
+    <% end %>
+    </div>
+
+    <!-- Indicators -->
+    <ol class="carousel-indicators">
+      <%= safe_join(indicators, "\n") %>
+    </ol>
+
+    <!-- Controls -->
+    <a class="left carousel-control prev" href="#<%= html_id %>" data-slide="prev">
+      <span class="glyphicon glyphicon-chevron-left"></span>
+    </a>
+    <a class="right carousel-control next" href="#<%= html_id %>" data-slide="next">
+      <span class="glyphicon glyphicon-chevron-right"></span>
+    </a>
+  </div>
+<% end %>
+</div>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
@@ -1,0 +1,43 @@
+<% solr_documents_features_block.with_solr_helper(self) %>
+<% indicators = [] %>
+<% html_id = "carousel-#{solr_documents_features_block.object_id}" %>
+
+<div class="content-block item-features">
+  <% if solr_documents_features_block.documents? %>
+  <div id="<%= html_id %>" class="row carousel" data-ride="carousel"  data-interval="false">
+      <div class="col-sm-6">
+        <div class="carousel-inner">
+          <% solr_documents_features_block.each_document.each_with_index do |(block_options, document), index| %>
+            <% doc_presenter = index_presenter(document) %>
+            <div class="item <%= 'active' if index == 0 %>" data-id="<%= document.id %>">
+              <% if block_options[:full_image_url].present? %>
+                <%= link_to_document(document, image_tag(block_options[:full_image_url], alt: ""), counter: -1) %>
+              <% elsif block_options[:iiif_tilesource_base].present?  %>
+                <%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!800,800/0/default.jpg', alt: ""), counter: -1) %>
+              <% elsif has_thumbnail? document %>
+                <%= render_thumbnail_tag(document, {}, document_counter: -1) %>
+              <% end %>
+            </div>
+
+            <% indicators << capture do %>
+              <li data-target="#<%= html_id %>" data-slide-to="<%= index %>" class="list-group-item <%= 'active' if index == 0 %>">
+                <a href="#" title="<%= (caption_text = doc_presenter.field_value(solr_documents_features_block.primary_caption? ? solr_documents_features_block.primary_caption_field : document_show_link_field)) %>">
+                  <%= truncate(caption_text, length: 95) %>
+                </a>
+                <% if solr_documents_features_block.secondary_caption? %>
+                  <p><%= doc_presenter.field_value solr_documents_features_block.secondary_caption_field %></p>
+                <% end %>
+              </li>
+            <% end %>
+
+          <% end %>
+        </div>
+      </div>
+
+      <!-- Indicators -->
+      <ol class="carousel-indicators col-sm-6 list-group list-striped">
+        <%= safe_join(indicators, "\n") %>
+      </ol>
+    </div>
+  <% end %>
+</div>

--- a/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/lib/generators/spotlight/tamu/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,0 +1,28 @@
+<% solr_documents_grid_block.with_solr_helper(self) %>
+<div class="content-block item-grid-block row">
+  <div class="items-col <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %> pull-<%= solr_documents_grid_block.content_align %>">
+    <% if solr_documents_grid_block.documents? %>
+        <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>
+          <div class="box item-<%= index %>" data-id="<%= document.id %>">
+            <% if block_options[:thumbnail_image_url].present? %>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:thumbnail_image_url], alt: ""), counter: -1) %></div>
+            <% elsif block_options[:iiif_tilesource_base].present?  %>
+              <div class="thumbnail"><%= link_to_document(document, image_tag(block_options[:iiif_tilesource_base] + '/full/!400,400/0/default.jpg', alt: ""), counter: -1) %></div>
+            <% elsif has_thumbnail? document %>
+              <div class="thumbnail"><%= render_thumbnail_tag(document, {}, document_counter: -1) %></div>
+            <% end %>
+          </div>
+        <% end %>
+    <% end %>
+  </div>
+
+
+  <% if solr_documents_grid_block.text? %>
+    <div class="text-col col-md-3">
+      <% unless solr_documents_grid_block.title.blank? %>
+        <h3><%= solr_documents_grid_block.title %></h3>
+      <% end %>
+      <%= sir_trevor_markdown solr_documents_grid_block.text %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
only addition to overrides was adding ```, alt: ""``` to image_tag helper